### PR TITLE
fix: import paths for masterchef integration tests

### DIFF
--- a/test/vault/integration/sushi/masterChefV1/MasterChefV1Adapter.t.sol
+++ b/test/vault/integration/sushi/masterChefV1/MasterChefV1Adapter.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 
-import { MasterChefV1Adapter, SafeERC20, IERC20, IERC20Metadata, Math, IMasterChefV1, IStrategy, IAdapter, IWithRewards } from "../../../../../../src/vault/adapter/sushi/masterChefV1/MasterChefV1Adapter.sol";
+import { MasterChefV1Adapter, SafeERC20, IERC20, IERC20Metadata, Math, IMasterChefV1, IStrategy, IAdapter, IWithRewards } from "../../../../../src/vault/adapter/sushi/masterChefV1/MasterChefV1Adapter.sol";
 import { MasterChefV1TestConfigStorage, MasterChefV1TestConfig } from "./MasterChefV1TestConfigStorage.sol";
 import { AbstractAdapterTest, ITestConfigStorage } from "../../abstract/AbstractAdapterTest.sol";
 import { MockStrategyClaimer } from "../../../../utils/mocks/MockStrategyClaimer.sol";

--- a/test/vault/integration/sushi/masterChefV2/MasterChefV2Adapter.t.sol
+++ b/test/vault/integration/sushi/masterChefV2/MasterChefV2Adapter.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.15;
 
 import { Test } from "forge-std/Test.sol";
 
-import { MasterChefV2Adapter, SafeERC20, IERC20, IERC20Metadata, Math, IMasterChefV2, IStrategy, IAdapter, IWithRewards } from "../../../../../../src/vault/adapter/sushi/masterChefV2/MasterChefV2Adapter.sol";
+import { MasterChefV2Adapter, SafeERC20, IERC20, IERC20Metadata, Math, IMasterChefV2, IStrategy, IAdapter, IWithRewards } from "../../../../../src/vault/adapter/sushi/masterChefV2/MasterChefV2Adapter.sol";
 import { MasterChefV2TestConfigStorage, MasterChefV2TestConfig } from "./MasterChefV2TestConfigStorage.sol";
 import { AbstractAdapterTest, ITestConfigStorage } from "../../abstract/AbstractAdapterTest.sol";
 import { MockStrategyClaimer } from "../../../../utils/mocks/MockStrategyClaimer.sol";


### PR DESCRIPTION
The import paths in the Masterchef tests are broken. Because of that Foundry compiles the whole project every time you run tests instead of just updating the files that have changed.

Since the project is quite large that takes a couple of seconds. Pretty annoying. This change fixes the issue for me.