### PR TITLE
wip: MultiStrategyVault

### DIFF
--- a/src/vault/MultiStrategyVault.sol
+++ b/src/vault/MultiStrategyVault.sol
@@ -237,7 +237,7 @@ contract MultiStrategyVault is
                 1e18,
                 Math.Rounding.Down
             ) * offset;
-            if (allocated > remainingShares || i == adapterCount - 1) {
+            if (i == adapterCount - 1) {
                 allocated = remainingShares;
             }
             adapters[i].adapter.mint(allocated, address(this));
@@ -356,7 +356,7 @@ contract MultiStrategyVault is
                 1e18,
                 Math.Rounding.Down
             ) * offset;
-            if (remainingShares < allocated || i == adapterCount - 1) {
+            if (i == adapterCount - 1) {
                 allocated = remainingShares;
             }
             adapters[i].adapter.redeem(allocated, address(this), address(this));

--- a/src/vault/MultiStrategyVault.sol
+++ b/src/vault/MultiStrategyVault.sol
@@ -230,17 +230,17 @@ contract MultiStrategyVault is
 
         IERC20(asset()).safeTransferFrom(caller, address(this), assets);
 
-        uint remainingAssets = assets;
+        uint remainingAssets = shares;
         for (uint8 i; i < adapterCount; i++) {
-            uint allocated = assets.mulDiv(
+            uint allocated = (shares / 10**decimalOffset).mulDiv(
                 adapters[i].allocation,
                 1e18,
                 Math.Rounding.Down
-            );
+            ) * 10**decimalOffset;
             if (allocated > remainingAssets || i == adapterCount - 1) {
                 allocated = remainingAssets;
             }
-            adapters[i].adapter.deposit(allocated, address(this));
+            adapters[i].adapter.mint(allocated, address(this));
             remainingAssets -= allocated;
         }
 
@@ -315,6 +315,7 @@ contract MultiStrategyVault is
             1e18,
             Math.Rounding.Down
         );
+        console.log("fee shares: ", feeShares);
 
         assets = _convertToAssets(shares - feeShares, Math.Rounding.Down);
         console.log("assets you get from redeem: ", assets);

--- a/test/vault/MultiStrategyVault.t.sol
+++ b/test/vault/MultiStrategyVault.t.sol
@@ -507,7 +507,9 @@ contract MultiStrategyVaultTester is Test {
             "pd"
         );
         assertEq(multiStrategyVault.totalSupply(), aliceShareAmount, "ts");
-        assertEq(multiStrategyVault.totalAssets(), aliceAssetAmount, "ta");
+        // rounding can cause the totalAssets to be lower than the deposited amount.
+        // Shouldn't be an issue after the first deposit 
+        assertApproxEqAbs(multiStrategyVault.totalAssets(), aliceAssetAmount, 1, "ta");
         assertEq(multiStrategyVault.balanceOf(alice), aliceShareAmount, "bal");
         assertApproxEqAbs(
             multiStrategyVault.convertToAssets(

--- a/test/vault/MultiStrategyVault.t.sol
+++ b/test/vault/MultiStrategyVault.t.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std/Test.sol";
 import {MockERC20} from "../utils/mocks/MockERC20.sol";
 import {MockERC4626} from "../utils/mocks/MockERC4626.sol";
 import {MultiStrategyVault, AdapterConfig, VaultFees} from "../../src/vault/MultiStrategyVault.sol";
+import { IAdapter } from "../../src/interfaces/vault/IAdapter.sol";
 import {IERC4626Upgradeable as IERC4626, IERC20Upgradeable as IERC20} from "openzeppelin-contracts-upgradeable/interfaces/IERC4626Upgradeable.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {Clones} from "openzeppelin-contracts/proxy/Clones.sol";
@@ -129,13 +130,15 @@ contract MultiStrategyVaultTester is Test {
         // - two users
         // - one mints the other deposits
         // - one redeems the other withdraws
-        // - vault and adapter both take fees
+        // - vault takes fees
         // - the adapter earn yield
         vm.assume(depositAmount > 0 && depositAmount <= 1000e18);
         vm.assume(mintAmount >= 1e9 && mintAmount <= 1000e27);
         vm.assume(adapterYield <= 1000e18);
         vm.assume(withdrawAmount > 0 && withdrawAmount <= depositAmount);
         vm.assume(redeemAmount > 1e9 && redeemAmount <= mintAmount);
+    
+        _setFees(1e16, 1e16, 0, 0);
     
         asset.mint(alice, depositAmount);
         vm.startPrank(alice);

--- a/test/vault/MultiStrategyVault.t.sol
+++ b/test/vault/MultiStrategyVault.t.sol
@@ -132,13 +132,15 @@ contract MultiStrategyVaultTester is Test {
         // - one redeems the other withdraws
         // - vault takes fees
         // - the adapter earn yield
-        vm.assume(depositAmount > 0 && depositAmount <= 1000e18);
-        vm.assume(mintAmount >= 1e9 && mintAmount <= 1000e27);
+        uint withdrawalFee = 0.01e18; // 1%
+        vm.assume(depositAmount >= 100 && depositAmount <= 1000e18);
+        vm.assume(mintAmount >= 100e9 && mintAmount <= 1000e27);
         vm.assume(adapterYield <= 1000e18);
-        vm.assume(withdrawAmount > 0 && withdrawAmount <= depositAmount);
-        vm.assume(redeemAmount > 1e9 && redeemAmount <= mintAmount);
+        // got to limit the withdrawal amount so that amount + fees doesn't exceed user's balance
+        vm.assume(withdrawAmount > 0 && withdrawAmount <= depositAmount * (1e18 - withdrawalFee) / 1e18);
+        vm.assume(redeemAmount > 0 && redeemAmount <= mintAmount * (1e18 - withdrawalFee) /  1e18);
     
-        _setFees(1e16, 1e16, 0, 0);
+        _setFees(0, uint64(withdrawalFee), 0, 0);
     
         asset.mint(alice, depositAmount);
         vm.startPrank(alice);


### PR DESCRIPTION
Still a work in progress. But I wanted to push the current state to keep you up to date.

- The approach is to ignore the rounding issue by dumping the last remaining tokens into the last adapter. While that might cause small differences in the final distribution of tokens they should be negligible.
- The fuzz tests find valid inputs that cause rounding issues that will cause a tx to revert, e.g. `test__mint_redeem()` fails with `147542663186274999434967457699000000001` as its input. Still working on that

The original approach had a couple of issues:
1. **it doesn't take into account that the assets of each adapter grow at a different rate.**
Let's say you have 3 adapters with the following weights: 25%, 25%, and 50%. You now deposit 20 tokens giving you 20 vault shares back. A couple of months pass and the adapters earn yield on your deposit. Their balances are 7, 9, and 17 respectively. If you now try to redeem your 20 shares, the number of assets you're supposed to get is $7 + 9 + 17 = 33$. The [`_withdraw()`](https://github.com/Popcorn-Limited/contracts/compare/feat/MultiStrategyVault...0xruhum:popcorn-contracts:feat/MultiStrategyVault#diff-4fc05f6774f8c9a15ae3de3d53a35a8c1097586ea294f0777a220868bb1181a9L358) function will then withdraw those assets by dividing the number of assets by each adapter's weight. So for the first adapter, it will try to withdraw $33 * 0.25 = 8.25$ tokens. That's more than the adapter has causing the tx to revert.

2. **share -> asset and asset -> share doesn't take into account adapter fees**
This is an issue that also applies to the base vault implementation. `totalAssets()` is supposed to take into account any fees. The vault calculates the total assets by calling `convertToAssets()` which does **not** take into account any fees. Instead you have to use `previewRedeem()` which will return the assets minus any fees you'd pay on withdrawal.