### PR TITLE
test: UniV3 & Curve compounder

### DIFF
--- a/test/vault/strategy/compounder/curve/CurveStargateCompounder.t.sol
+++ b/test/vault/strategy/compounder/curve/CurveStargateCompounder.t.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.15;
 import {Test} from "forge-std/Test.sol";
 import {StargateLpStakingAdapter, SafeERC20, IERC20, IERC20Metadata, Math, IStargateStaking} from "../../../../../src/vault/adapter/stargate/lpStaking/StargateLpStakingAdapter.sol";
 import {CurveStargateCompounder, CurveRoute} from "../../../../../src/vault/strategy/compounder/curve/CurveStargateCompounder.sol";
+import {CurveCompounder} from "../../../../../src/vault/strategy/compounder/curve/CurveCompounder.sol";
 import {Clones} from "openzeppelin-contracts/proxy/Clones.sol";
 
 contract CurveStargateCompounderTest is Test {
@@ -54,7 +55,7 @@ contract CurveStargateCompounderTest is Test {
         curveRoutes.push(
             CurveRoute({route: toBaseAssetRoute, swapParams: swapParams})
         );
-        minTradeAmounts.push(uint256(0));
+        minTradeAmounts.push(uint256(1e18));
 
         bytes memory stratData = abi.encode(
             usdc,
@@ -80,6 +81,14 @@ contract CurveStargateCompounderTest is Test {
             address(stargateStaking),
             abi.encode(0)
         );
+
+        // we deposit the initial funds so that the adapter actually holds some assets.
+        // We also increase the block timestamp so that `harvest()` is executed when we
+        // call it in one of the tests.
+        deal(asset, address(this), 10000e6);
+        IERC20(asset).approve(address(adapter), type(uint256).max);
+        adapter.deposit(10000e6, address(this));
+        vm.warp(block.timestamp + 12);
     }
 
     function test__init() public {
@@ -94,10 +103,6 @@ contract CurveStargateCompounderTest is Test {
     }
 
     function test__compound() public {
-        deal(asset, address(this), 10000e6);
-        IERC20(asset).approve(address(adapter), type(uint256).max);
-        adapter.deposit(10000e6, address(this));
-
         uint256 oldTa = adapter.totalAssets();
 
         vm.roll(block.number + 10_000);
@@ -107,4 +112,85 @@ contract CurveStargateCompounderTest is Test {
 
         assertGt(adapter.totalAssets(), oldTa);
     }
+
+    function test__min_trade_amount() public {
+        // the strategy should only compound if its balance > minTradeAmount
+        deal(stg, address(adapter), 1e17);
+        adapter.harvest();
+
+        assertGt(IERC20(stg).balanceOf(address(adapter)), 0, "shouldn't trade if minAmount > balance");
+    }
+
+    function test__should_trade_whole_balance() public {
+        // when trading, it should use all the available funds
+        vm.roll(block.number + 10_000);
+        vm.warp(block.timestamp + 120_000);
+
+        adapter.harvest();
+
+        assertEq(IERC20(stg).balanceOf(address(this)), 0, "should trade whole balance");
+    }
+
+    function test__should_hold_no_tokens() public {
+        // after trading, the adapter shouldn't hold any additional assets.
+        // The funds it got from the trade should be deposited.
+        // so oldBalance = newBalance for the underlying asset
+        uint oldBal = IERC20(asset).balanceOf(address(adapter));
+
+        vm.roll(block.number + 10_000);
+        vm.warp(block.timestamp + 120_000);
+
+        adapter.harvest();
+
+        uint newBal = IERC20(asset).balanceOf(address(adapter));
+        assertEq(oldBal, newBal, "shouldn't hold any assets in adapter");
+    }
+
+    function test__init_only_allow_asset() public {
+        // token that we trade to MUST be the base asset used to get the adapter's asset.
+        // In this case it would be USDC but we swap to asset (Stargate LP token)
+        toBaseAssetRoute[2] = asset;
+        curveRoutes[0] = CurveRoute({route: toBaseAssetRoute, swapParams: swapParams});
+        CurveRoute memory toAssetStruct = CurveRoute({
+            route: toBaseAssetRoute,
+            swapParams: swapParams
+        });
+
+        bytes memory stratData = abi.encode(
+            usdc,
+            router,
+            curveRoutes,
+            toAssetStruct,
+            minTradeAmounts,
+            abi.encode(stargateRouter)
+        );
+        address impl = address(new StargateLpStakingAdapter());
+        StargateLpStakingAdapter _adapter = StargateLpStakingAdapter(Clones.clone(impl));
+
+        // need to do this before the call to initalize because expectRevert
+        // would try to catch this call otherwise
+        CurveStargateCompounder compounder = new CurveStargateCompounder();
+        vm.expectRevert(CurveCompounder.InvalidConfig.selector);
+        _adapter.initialize(
+            abi.encode(
+                asset,
+                address(this),
+                compounder,
+                0,
+                sigs,
+                stratData
+            ),
+            address(stargateStaking),
+            abi.encode(0)
+        );
+    }
+
+    function test__no_rewards_available() public {
+        uint totalAssets = adapter.totalAssets();
+
+        adapter.harvest();
+
+        assertEq(totalAssets, adapter.totalAssets(), "totalAssets shouldn't change if there are no reward tokens");
+    }
+
 }

--- a/test/vault/strategy/compounder/uni/v3/UniV3StargateCompounder.t.sol
+++ b/test/vault/strategy/compounder/uni/v3/UniV3StargateCompounder.t.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.15;
 import {Test} from "forge-std/Test.sol";
 import {StargateLpStakingAdapter, SafeERC20, IERC20, IERC20Metadata, Math, IStargateStaking} from "../../../../../../src/vault/adapter/stargate/lpStaking/StargateLpStakingAdapter.sol";
 import {UniV3StargateCompounder, UniswapV3Utils} from "../../../../../../src/vault/strategy/compounder/uni/v3/UniV3StargateCompounder.sol";
+import {UniV3Compounder} from "../../../../../../src/vault/strategy/compounder/uni/v3/UniV3Compounder.sol";
 import {Clones} from "openzeppelin-contracts/proxy/Clones.sol";
 
 contract UniV3StargateCompounderTest is Test {
@@ -29,7 +30,7 @@ contract UniV3StargateCompounderTest is Test {
         vm.selectFork(forkId);
 
         toBaseAssetPaths.push(abi.encodePacked(stg, uint24(3000), usdc));
-        minTradeAmounts.push(uint256(0));
+        minTradeAmounts.push(uint256(100));
 
         bytes memory stratData = abi.encode(
             usdc,
@@ -55,6 +56,14 @@ contract UniV3StargateCompounderTest is Test {
             address(stargateStaking),
             abi.encode(0)
         );
+
+        // we deposit the initial funds so that the adapter actually holds some assets.
+        // We also increase the block timestamp so that `harvest()` is executed when we
+        // call it in one of the tests.
+        deal(asset, address(this), 10000e6);
+        IERC20(asset).approve(address(adapter), type(uint256).max);
+        adapter.deposit(10000e6, address(this));
+        vm.warp(block.timestamp + 12);
     }
 
     function test__init() public {
@@ -69,17 +78,91 @@ contract UniV3StargateCompounderTest is Test {
     }
 
     function test__compound() public {
-        deal(asset, address(this), 10000e6);
-        IERC20(asset).approve(address(adapter), type(uint256).max);
-        adapter.deposit(10000e6, address(this));
-
         uint256 oldTa = adapter.totalAssets();
 
         vm.roll(block.number + 10_000);
-        vm.warp(block.timestamp + 150_000);
+        vm.warp(block.timestamp + 120_000);
 
         adapter.harvest();
 
         assertGt(adapter.totalAssets(), oldTa);
     }
+
+    function test__min_trade_amount() public {
+        // the strategy should only compound if its balance > minTradeAmount
+        deal(stg, address(adapter), 99); // 1 lower than minTradeAmount
+        adapter.harvest();
+
+        assertEq(IERC20(stg).balanceOf(address(adapter)), 99, "shouldn't trade if minAmount > balance");
+    }
+
+    function test__should_trade_whole_balance() public {
+        // when trading, it should use all the available funds
+        vm.roll(block.number + 10_000);
+        vm.warp(block.timestamp + 120_000);
+
+        adapter.harvest();
+
+        assertEq(IERC20(stg).balanceOf(address(this)), 0, "should trade whole balance");
+    }
+
+    function test__should_hold_no_tokens() public {
+        // after trading, the adapter shouldn't hold any additional assets.
+        // The funds it got from the trade should be deposited.
+        // so oldBalance = newBalance for the underlying asset
+        uint oldBal = IERC20(asset).balanceOf(address(adapter));
+
+        vm.roll(block.number + 10_000);
+        vm.warp(block.timestamp + 120_000);
+
+        adapter.harvest();
+
+        uint newBal = IERC20(asset).balanceOf(address(adapter));
+        assertEq(oldBal, newBal, "shouldn't hold any assets in adapter");
+    }
+
+    function test__init_only_allow_asset() public {
+        // token that we trade to MUST be the base asset used to get the adapter's asset.
+        // In this case it would be USDC but we swap to asset (Stargate LP token)
+        bytes[] memory _toBaseAssetPaths = new bytes[](1);
+        _toBaseAssetPaths[0] = abi.encodePacked(stg, uint24(3000), asset);
+
+        bytes memory stratData = abi.encode(
+            usdc,
+            router,
+            _toBaseAssetPaths,
+            "",
+            minTradeAmounts,
+            abi.encode(stargateRouter)
+        );
+
+        address impl = address(new StargateLpStakingAdapter());
+        StargateLpStakingAdapter _adapter = StargateLpStakingAdapter(Clones.clone(impl));
+
+        // need to do this before the call to initalize because expectRevert
+        // would try to catch this call otherwise
+        UniV3StargateCompounder compounder = new UniV3StargateCompounder();
+        vm.expectRevert(UniV3Compounder.InvalidConfig.selector);
+        _adapter.initialize(
+            abi.encode(
+                asset,
+                address(this),
+                compounder,
+                0,
+                sigs,
+                stratData
+            ),
+            address(stargateStaking),
+            abi.encode(0)
+        );
+    }
+
+    function test__no_rewards_available() public {
+        uint totalAssets = adapter.totalAssets();
+
+        adapter.harvest();
+
+        assertEq(totalAssets, adapter.totalAssets(), "totalAssets shouldn't change if there are no reward tokens");
+    }
+
 }


### PR DESCRIPTION
- we force a strategy to specify a `minTradeAmount` for each reward token. Otherwise, it tries to swap 0 tokens causing the call to `harvest()` to fail.
- if `harvest()` doesn't get us any `baseAsset` we return early since we have no tokens to swap to the adapter's underlying asset.