### PR TITLE
fix: revert if Strategy.setUp() fails

### DIFF
--- a/src/vault/adapter/abstracts/AdapterBase.sol
+++ b/src/vault/adapter/abstracts/AdapterBase.sol
@@ -313,6 +313,8 @@ abstract contract AdapterBase is
         (bool success, ) = address(strategy).delegatecall(
             abi.encodeWithSignature("setUp(bytes)", strategyConfig)
         );
+    
+        if (!success) revert StrategySetupFailed();
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
`setUp()` currently only approves tokens to relevant contracts, e.g. routers. But that might change in the future. Generally, we expect the adapter to not function properly if `Strategy.setUp()` failed so we shouldn't allow that to happen.