### PR TITLE
Sketch - Inheritance based Vault

### DIFF
--- a/src/vault/BaseVault.sol
+++ b/src/vault/BaseVault.sol
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: GPL-3.0
+// Docgen-SOLC: 0.8.15
+
+pragma solidity ^0.8.15;
+
+import {
+    ERC4626Upgradeable,
+    IERC20Upgradeable as IERC20,
+    IERC20MetadataUpgradeable as IERC20Metadata,
+    ERC20Upgradeable as ERC20
+} from "openzeppelin-contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import {SafeERC20Upgradeable as SafeERC20} from
+    "openzeppelin-contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import {ReentrancyGuardUpgradeable} from "openzeppelin-contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import {MathUpgradeable as Math} from "openzeppelin-contracts-upgradeable/utils/math/MathUpgradeable.sol";
+import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/security/PausableUpgradeable.sol";
+import {EIP165} from "../utils/EIP165.sol";
+import {OwnedUpgradeable} from "../utils/OwnedUpgradeable.sol";
+import {VaultFees} from "../interfaces/vault/IVault.sol";
+
+struct BaseVaultInitData {
+    address asset;
+    string name;
+    string symbol;
+    address owner;
+    VaultFees fees;
+    address feeRecipient;
+    uint depositLimit;
+}
+
+/**
+ * @title   baseVault
+ * @author  RedVeil
+ * @notice  See the following for the full EIP-4626 specification https://eips.ethereum.org/EIPS/eip-4626.
+ *
+ * The ERC4626 compliant base contract for all adapter contracts.
+ * It allows interacting with an underlying protocol.
+ * All specific interactions for the underlying protocol need to be overriden in the actual implementation.
+ * The adapter can be initialized with a strategy that can perform additional operations. (Leverage, Compounding, etc.)
+ */
+abstract contract BaseVault is
+    ERC4626Upgradeable,
+    PausableUpgradeable,
+    OwnedUpgradeable,
+    ReentrancyGuardUpgradeable,
+    EIP165
+{
+    using SafeERC20 for IERC20;
+    using Math for uint256;
+
+    uint8 internal _decimals;
+    uint8 public constant decimalOffset = 9;
+
+    uint depositLimit;
+    bytes32 contractName;
+
+    event VaultInitialized(bytes32 contractName, address indexed asset);
+
+    error StrategySetupFailed();
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize a new Vault.
+     * @dev `asset` - The underlying asset
+     * @dev `_owner` - Owner of the contract. Controls management functions.
+     * @dev `_strategy` - An optional strategy to enrich the adapter with additional functionality.
+     * @dev `_harvestCooldown` - Cooldown period between harvests.
+     * @dev `_requiredSigs` - Function signatures required by the strategy (EIP-165)
+     * @dev `_strategyConfig` - Additional data which can be used by the strategy on `harvest()`
+     * @dev This function is called by the factory contract when deploying a new vault.
+     * @dev Each Adapter implementation should implement checks to make sure that the adapter is wrapping the underlying protocol correctly.
+     * @dev If a strategy is provided, it will be verified to make sure it implements the required functions.
+     */
+    function __BaseVault__init(BaseVaultInitData memory initData) internal onlyInitializing {
+        __Owned_init(initData.owner);
+        __Pausable_init();
+        __ERC4626_init(IERC20Metadata(initData.asset));
+
+        INITIAL_CHAIN_ID = block.chainid;
+        INITIAL_DOMAIN_SEPARATOR = computeDomainSeparator();
+
+        _decimals = IERC20Metadata(initData.asset).decimals() + decimalOffset; // Asset decimals + decimal offset to combat inflation attacks
+        highWaterMark = 1e9;
+
+        fees = initData.fees;
+        feeRecipient = initData.feeRecipient;
+    
+        depositLimit = initData.depositLimit;
+
+        // _name = initData.name;
+        // _symbol = initData.symbol;
+
+        contractName = keccak256(
+            abi.encodePacked("Popcorn", initData.name, block.timestamp, "Vault")
+        ); 
+
+        quitPeriod = 3 days;
+
+        emit VaultInitialized(contractName, address(initData.asset));
+    }
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        DEPOSIT/WITHDRAWAL LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _afterDeposit() internal virtual;
+    function _afterWithdrawal() internal virtual;
+
+    error MaxError(uint256 amount);
+    error ZeroAmount();
+
+    function deposit(uint assets, address receiver) public override nonReentrant whenNotPaused returns (uint shares) {
+        if (assets > maxDeposit(receiver)) revert MaxError(assets);
+    
+        /// @dev Inititalize account for managementFee on first deposit
+        if (totalSupply() == 0) feesUpdatedAt = block.timestamp;
+
+        uint feeShares = _convertToShares(
+            assets.mulDiv(uint256(fees.deposit), 1e18, Math.Rounding.Down),
+            Math.Rounding.Down
+        );
+
+        shares = _convertToShares(assets, Math.Rounding.Down) - feeShares;
+        if (shares == 0) revert ZeroAmount();
+
+        if (feeShares > 0) _mint(feeRecipient, feeShares);
+
+        _deposit(msg.sender, receiver, assets, shares); 
+    }
+
+    /**
+     * @notice Mint exactly `shares` vault shares to `receiver`, taking the necessary amount of `asset` from the caller.
+     * @param shares Quantity of shares to mint.
+     * @param receiver Receiver of issued vault shares.
+     * @return assets Quantity of assets deposited by caller.
+     */
+    function mint(
+        uint256 shares,
+        address receiver
+    ) public override nonReentrant whenNotPaused returns (uint256 assets) {
+        if (shares > maxMint(receiver)) revert MaxError(assets);
+
+        // Inititalize account for managementFee on first deposit
+        if (totalSupply() == 0) feesUpdatedAt = block.timestamp;
+
+        uint256 feeShares = shares.mulDiv(
+            uint(fees.deposit),
+            1e18 - uint(fees.deposit),
+            Math.Rounding.Down
+        );
+
+        assets = _convertToAssets(shares + feeShares, Math.Rounding.Up);
+
+        if (feeShares > 0) _mint(feeRecipient, feeShares);
+    
+        _deposit(msg.sender, receiver, assets, shares);
+    }
+
+
+    /**
+     * @notice Deposit `assets` into the underlying protocol and mints vault shares to `receiver`.
+     * @dev Executes harvest if `harvestCooldown` is passed since last invocation.
+     */
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares)
+        internal
+        virtual
+        override
+        nonReentrant
+    {
+        IERC20(asset()).safeTransferFrom(caller, address(this), assets);
+
+        _protocolDeposit(assets, shares);
+        _mint(receiver, shares);
+
+        _afterDeposit();
+
+        emit Deposit(caller, receiver, assets, shares);
+    }
+
+    /**
+     * @notice Withdraws `assets` from the underlying protocol and burns vault shares from `owner`.
+     * @dev Executes harvest if `harvestCooldown` is passed since last invocation.
+     */
+    function _withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
+        internal
+        virtual
+        override
+    {
+        if (caller != owner) {
+            _spendAllowance(owner, caller, shares);
+        }
+
+        if (!paused()) {
+            _protocolWithdraw(assets, shares);
+        }
+
+        _burn(owner, shares);
+
+        IERC20(asset()).safeTransfer(receiver, assets);
+
+        _afterWithdrawal();
+
+        emit Withdraw(caller, receiver, owner, assets, shares);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ACCOUNTING LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Total amount of underlying `asset` token managed by adapter.
+     * @dev Return assets held by adapter if paused.
+     */
+    function totalAssets() public view override returns (uint256) {
+        return paused() ? IERC20(asset()).balanceOf(address(this)) : _totalAssets();
+    }
+
+    /**
+     * @notice Total amount of underlying `asset` token managed by adapter through the underlying protocol.
+     */
+    function _totalAssets() internal view virtual returns (uint256) {}
+
+    /**
+     * @notice Convert either `assets` or `shares` into underlying shares.
+     * @dev This is an optional function for underlying protocols that require deposit/withdrawal amounts in their shares.
+     * @dev Returns shares if totalSupply is 0.
+     */
+    function convertToUnderlyingShares(uint256 assets, uint256 shares) public view virtual returns (uint256) {}
+
+    /**
+     * @notice Simulate the effects of a deposit at the current block, given current on-chain conditions.
+     * @dev Return 0 if paused since no further deposits are allowed.
+     * @dev Override this function if the underlying protocol has a unique deposit logic and/or deposit fees.
+     */
+    function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
+        return paused() ? 0 : _convertToShares(assets, Math.Rounding.Down);
+    }
+
+    /**
+     * @notice Simulate the effects of a mint at the current block, given current on-chain conditions.
+     * @dev Return 0 if paused since no further deposits are allowed.
+     * @dev Override this function if the underlying protocol has a unique deposit logic and/or deposit fees.
+     */
+    function previewMint(uint256 shares) public view virtual override returns (uint256) {
+        return paused() ? 0 : _convertToAssets(shares, Math.Rounding.Up);
+    }
+
+    function _convertToShares(uint256 assets, Math.Rounding rounding)
+        internal
+        view
+        virtual
+        override
+        returns (uint256 shares)
+    {
+        return assets.mulDiv(totalSupply() + 10 ** decimalOffset, totalAssets() + 1, rounding);
+    }
+
+    function _convertToAssets(uint256 shares, Math.Rounding rounding)
+        internal
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return shares.mulDiv(totalAssets() + 1, totalSupply() + 10 ** decimalOffset, rounding);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                     DEPOSIT/WITHDRAWAL LIMIT LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+
+    /// @return Maximum amount of underlying `asset` token that may be deposited for a given address. 
+    function maxDeposit(address) public view override returns (uint256) {
+        uint256 assets = totalAssets();
+        uint256 depositLimit_ = depositLimit;
+        if (paused() || assets >= depositLimit_) return 0;
+        return depositLimit_ - assets;
+    }
+
+    /// @return Maximum amount of vault shares that may be minted to given address. 
+    function maxMint(address) public view override returns (uint256) {
+        uint256 assets = totalAssets();
+        uint256 depositLimit_ = depositLimit;
+        if (paused() || assets >= depositLimit_) return 0;
+        return _convertToShares(depositLimit_ - assets, Math.Rounding.Down);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      FEE LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 public performanceFee;
+    uint256 public highWaterMark;
+    uint public feesUpdatedAt;
+
+    address public constant FEE_RECIPIENT = address(0x47fd36ABcEeb9954ae9eA1581295Ce9A8308655E);
+
+    event PerformanceFeeChanged(uint256 oldFee, uint256 newFee);
+
+    error InvalidPerformanceFee(uint256 fee);
+
+    /**
+     * @notice Performance fee that has accrued since last fee harvest.
+     * @return Accrued performance fee in underlying `asset` token.
+     * @dev Performance fee is based on a high water mark value. If vault share value has increased above the
+     *   HWM in a fee period, issue fee shares to the vault equal to the performance fee.
+     */
+    function accruedPerformanceFee() public view returns (uint256) {
+        uint256 highWaterMark_ = highWaterMark;
+        uint256 shareValue = convertToAssets(1e18);
+        uint256 performanceFee_ = performanceFee;
+
+        return performanceFee_ > 0 && shareValue > highWaterMark_
+            ? performanceFee_.mulDiv((shareValue - highWaterMark_) * totalSupply(), 1e36, Math.Rounding.Down)
+            : 0;
+    }
+
+    /// @notice Minimal function to call `takeFees` modifier.
+    function takeManagementAndPerformanceFees()
+        external
+        nonReentrant
+        takeFees
+    {}
+
+    /**
+     * @notice Set a new performance fee for this adapter. Caller must be owner.
+     * @param newFee performance fee in 1e18.
+     * @dev Fees can be 0 but never more than 2e17 (1e18 = 100%, 1e14 = 1 BPS)
+     */
+    function setPerformanceFee(uint256 newFee) public onlyOwner {
+        // Dont take more than 20% performanceFee
+        if (newFee > 2e17) revert InvalidPerformanceFee(newFee);
+
+        emit PerformanceFeeChanged(performanceFee, newFee);
+
+        performanceFee = newFee;
+    }
+
+    // TODO: where to put this? We normally take fees with every harvest.
+    // But, what about vaults without a strategy, i.e. that don't harvest.
+
+    /// @notice Collect performance fees and update asset checkpoint.
+    modifier takeFees() {
+        _;
+        uint256 fee = accruedPerformanceFee();
+        uint256 shareValue = convertToAssets(1e18);
+
+        if (shareValue > highWaterMark) highWaterMark = shareValue;
+
+        if (fee > 0) _mint(FEE_RECIPIENT, convertToShares(fee));
+    }
+
+    VaultFees public fees;
+
+    VaultFees public proposedFees;
+    uint256 public proposedFeeTime;
+
+    address public feeRecipient;
+
+    event NewFeesProposed(VaultFees newFees, uint256 timestamp);
+    event ChangedFees(VaultFees oldFees, VaultFees newFees);
+    event FeeRecipientUpdated(address oldFeeRecipient, address newFeeRecipient);
+
+    error InvalidVaultFees();
+    error InvalidFeeRecipient();
+    error NotPassedQuitPeriod(uint256 quitPeriod);
+
+    /**
+    * @notice Propose new fees for this vault. Caller must be owner.
+    * @param newFees Fees for depositing, withdrawal, management and performance in 1e18.
+    * @dev Fees can be 0 but never 1e18 (1e18 = 100%, 1e14 = 1 BPS)
+    */
+   function proposeFees(VaultFees calldata newFees) external onlyOwner {
+       if (
+           newFees.deposit >= 1e18 ||
+           newFees.withdrawal >= 1e18 ||
+           newFees.management >= 1e18 ||
+           newFees.performance >= 1e18
+       ) revert InvalidVaultFees();
+
+       proposedFees = newFees;
+       proposedFeeTime = block.timestamp;
+
+       emit NewFeesProposed(newFees, block.timestamp);
+   }
+
+   /// @notice Change fees to the previously proposed fees after the quit period has passed.
+   function changeFees() external takeFees {
+       if (
+           proposedFeeTime == 0 ||
+           block.timestamp < proposedFeeTime + quitPeriod
+       ) revert NotPassedQuitPeriod(quitPeriod);
+
+       emit ChangedFees(fees, proposedFees);
+
+       fees = proposedFees;
+       feesUpdatedAt = block.timestamp;
+
+       delete proposedFees;
+       delete proposedFeeTime;
+   }
+
+   /**
+    * @notice Change `feeRecipient`. Caller must be Owner.
+    * @param _feeRecipient The new fee recipient.
+    * @dev Accrued fees wont be transferred to the new feeRecipient.
+    */
+   function setFeeRecipient(address _feeRecipient) external onlyOwner {
+       if (_feeRecipient == address(0)) revert InvalidFeeRecipient();
+
+       emit FeeRecipientUpdated(feeRecipient, _feeRecipient);
+
+       feeRecipient = _feeRecipient;
+   }
+
+    /*//////////////////////////////////////////////////////////////
+                      PAUSING LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Pause Deposits and withdraw all funds from the underlying protocol. Caller must be owner.
+    function pause() external onlyOwner {
+        _protocolWithdraw(totalAssets(), totalSupply());
+        _pause();
+    }
+
+    /// @notice Unpause Deposits and deposit all funds into the underlying protocol. Caller must be owner.
+    function unpause() external onlyOwner {
+        _protocolDeposit(totalAssets(), totalSupply());
+        _unpause();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        RAGE QUIT LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 public quitPeriod;
+
+    event QuitPeriodSet(uint256 quitPeriod);
+
+    error InvalidQuitPeriod();
+
+    /**
+     * @notice Set a quitPeriod for rage quitting after new adapter or fees are proposed. Caller must be Owner.
+     * @param _quitPeriod Time to rage quit after proposal.
+     */
+    function setQuitPeriod(uint256 _quitPeriod) external onlyOwner {
+        if (
+            block.timestamp < proposedFeeTime + quitPeriod
+        ) revert NotPassedQuitPeriod(quitPeriod);
+        if (_quitPeriod < 1 days || _quitPeriod > 7 days)
+            revert InvalidQuitPeriod();
+
+        quitPeriod = _quitPeriod;
+
+        emit QuitPeriodSet(quitPeriod);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          INTERNAL HOOKS LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice deposit into the underlying protocol.
+    function _protocolDeposit(uint256 assets, uint256 shares) internal virtual {
+        // OPTIONAL - convertIntoUnderlyingShares(assets,shares)
+    }
+
+    /// @notice Withdraw from the underlying protocol.
+    function _protocolWithdraw(uint256 assets, uint256 shares) internal virtual {
+        // OPTIONAL - convertIntoUnderlyingShares(assets,shares)
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      EIP-165 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        // TODO: need to add this
+        return false;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      EIP-2612 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    //  EIP-2612 STORAGE
+    uint256 internal INITIAL_CHAIN_ID;
+    bytes32 internal INITIAL_DOMAIN_SEPARATOR;
+    mapping(address => uint256) public nonces;
+
+    error PermitDeadlineExpired(uint256 deadline);
+    error InvalidSigner(address signer);
+
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        public
+        virtual
+    {
+        if (deadline < block.timestamp) revert PermitDeadlineExpired(deadline);
+
+        // Unchecked because the only math done is incrementing
+        // the owner's nonce which cannot realistically overflow.
+        unchecked {
+            address recoveredAddress = ecrecover(
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        DOMAIN_SEPARATOR(),
+                        keccak256(
+                            abi.encode(
+                                keccak256(
+                                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                                ),
+                                owner,
+                                spender,
+                                value,
+                                nonces[owner]++,
+                                deadline
+                            )
+                        )
+                    )
+                ),
+                v,
+                r,
+                s
+            );
+
+            if (recoveredAddress == address(0) || recoveredAddress != owner) {
+                revert InvalidSigner(recoveredAddress);
+            }
+
+            _approve(recoveredAddress, spender, value);
+        }
+    }
+
+    function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
+        return block.chainid == INITIAL_CHAIN_ID ? INITIAL_DOMAIN_SEPARATOR : computeDomainSeparator();
+    }
+
+    function computeDomainSeparator() internal view virtual returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(name())),
+                keccak256("1"),
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+}

--- a/src/vault/CurveLPCompounder.sol
+++ b/src/vault/CurveLPCompounder.sol
@@ -1,0 +1,227 @@
+pragma solidity ^0.8.15;
+
+import {VaultWithStrategy} from "./VaultWithStrategy.sol";
+import {BaseVaultInitData} from "./BaseVault.sol";
+import {IGauge, IMinter} from "./adapter/curve/ICurve.sol";
+import {ICurveRouter} from "../interfaces/external/curve/ICurveRouter.sol";
+import {IERC20} from "openzeppelin-contracts/interfaces/IERC20.sol";
+import {IERC20Metadata} from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
+
+struct CurveRoute {
+    address[9] route;
+    uint256[3][4] swapParams;
+}
+
+struct StrategyConfig {
+    uint256 autoHarvest;
+    uint256 harvestCooldown;
+    address router;
+    address baseAsset;
+    CurveRoute[] toBaseAssetRoutes;
+    uint256[] minTradeAmounts;
+    IPool pool;
+    uint baseAssetIndex; // the index is used in add_liquidity
+}
+
+interface IPool {
+    // TODO: add remaining functions for different number of coins
+    function add_liquidity(uint[3] memory amounts, uint minOut) external;
+}
+
+contract CurveLPCompounder is VaultWithStrategy {
+    IGauge gauge;
+    IMinter public minter;
+    address crv;
+
+    address router;
+    address baseAsset;
+    CurveRoute[] toBaseAssetRoutes;
+    uint256[] minTradeAmounts;
+    IPool pool;
+    uint baseAssetIndex;
+
+    /// @dev number of tokens in the curve pool
+    uint internal numberOfTokens;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(bytes calldata initData) external initializer {
+        // TODO: can we force the user to send BaseVaultInitData separately through the calldata?
+        // The struct is the same for all the vaults. We shouldn't need to encode it
+        (
+            BaseVaultInitData memory baseVaultInitData,
+            address _gauge,
+            address _minter,
+            StrategyConfig memory _stratConfig
+        ) = abi.decode(
+            initData, (BaseVaultInitData, address, address, StrategyConfig)
+        );
+        __VaultWithStrategy__init(baseVaultInitData, _stratConfig.autoHarvest, _stratConfig.harvestCooldown);
+        
+        gauge = IGauge(_gauge);
+        minter = IMinter(_minter);
+        crv = minter.token();
+        
+        router = _stratConfig.router;
+        baseAsset = _stratConfig.baseAsset;
+        /// @dev assigning `toBaseAssetRoutes = _stratConfig.toBaseAssetRoutes` doesn't work.
+        // we have to manually assign each index
+        for (uint i; i < _stratConfig.toBaseAssetRoutes.length;) {
+            toBaseAssetRoutes.push(_stratConfig.toBaseAssetRoutes[i]);
+            unchecked {
+                ++i;
+            }
+        }
+        minTradeAmounts = _stratConfig.minTradeAmounts;
+        pool = _stratConfig.pool;
+        baseAssetIndex = _stratConfig.baseAssetIndex;
+
+        IERC20(baseVaultInitData.asset).approve(_gauge, type(uint).max);
+
+        IERC20(_stratConfig.baseAsset).approve(address(_stratConfig.pool), type(uint).max);
+
+        address[] memory tokens = rewardTokens();
+        uint length = tokens.length;
+        for (uint i; i < length;) {
+            IERC20(tokens[i]).approve(_stratConfig.router, type(uint).max);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+
+    function harvest() public override {
+        lastHarvest = block.timestamp;
+
+        // cache for gas savings
+        IERC20 _asset = IERC20(asset());
+
+        uint balBefore = _asset.balanceOf(address(this));
+        
+        minter.mint(address(gauge));
+        _swapToBaseAsset();
+
+        if (IERC20(baseAsset).balanceOf(address(this)) == 0) {
+            emit Harvest();
+            return;
+        }
+
+        _getAsset();
+
+        strategyDeposit(_asset.balanceOf(address(this)) - balBefore, 0);
+    }
+
+    function rewardTokens() public view override returns (address[] memory) {
+        uint256 rewardCount = gauge.reward_count();
+        address[] memory _rewardTokens = new address[](rewardCount + 1);
+        _rewardTokens[0] = crv;
+        for (uint256 i; i < rewardCount; ++i) {
+            _rewardTokens[i + 1] = gauge.reward_tokens(i);
+        }
+        return _rewardTokens;
+    }
+
+    function _swapToBaseAsset()
+        internal
+    {
+        // Trade rewards for base asset
+        address[] memory tokens = rewardTokens();
+        uint256 len = tokens.length;
+        for (uint256 i; i < len;) {
+            uint256 rewardBal = IERC20(tokens[i]).balanceOf(address(this));
+            if (rewardBal >= minTradeAmounts[i]) {
+                ICurveRouter(router).exchange_multiple(
+                    toBaseAssetRoutes[i].route, toBaseAssetRoutes[i].swapParams, rewardBal, 0
+                );
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _getAsset()
+        internal
+        virtual
+    {
+        // Curve's `add_liquidity` expects a fixed-size array as the first argument.
+        // The size of the array depends on the pool.
+        // For example, 3CRV has a size of 3 while stETH/ETH has 2.
+        //
+        // Since our vault is supposed to be usable with all kinds of pools,
+        // we can't use a fixed-size array here. Calling the function with an
+        // unbounded one will revert. The reason is the way those two types of arrays
+        // are encoded.
+        // Fixed size arrays simply concatenate its values with each one taking up 32 bytes: 0, 1, 2
+        // see https://github.com/willitscale/learning-solidity/blob/master/support/INVALID_IMPLICIT_CONVERSION_OF_ARRAYS.MD#211-memory-layout
+        // Unbounded arrays do the same but add a 32 byte value at the beginning specifying its length:
+        // 3, 0, 1, 2 see https://github.com/willitscale/learning-solidity/blob/master/support/INVALID_IMPLICIT_CONVERSION_OF_ARRAYS.MD#221-memory-layout
+        //
+        // By building the calldata ourselves, we can have a general solution.
+        // That would be the "cleanest" one. But, it comes with hefty gas costs
+        // since building the calldata is pretty expensive. For one, you can't slice
+        // memory arrays right now. That's only supported for calldata. So you have to
+        // build a custom loop and concat each value.
+        // Because harvest() is a user-facing function we should prioritize
+        // gas usage more than code-quality
+        //
+        // Instead, we proceed with the "dumb" solution: a simple switch statement
+        //
+        // We can't do `uint[numberOfTokens]` either. Has to be a constant/literal value
+
+        // cache for gas savings
+        uint _numberOfTokens = numberOfTokens;
+
+        uint amount = IERC20(baseAsset).balanceOf(address(this));
+
+        // if (_numberOfTokens == 2) {
+        //     uint[2] memory amounts = [uint(0), 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // } else if (_numberOfTokens == 3) {
+        //     uint[3] memory amounts = [uint(0), 0, 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // } else if (_numberOfTokens == 4) {
+        //     uint[4] memory amounts = [uint(0), 0, 0, 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // } else if (_numberOfTokens == 5) {
+        //     uint[5] memory amounts = [uint(0), 0, 0, 0, 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // } else if (_numberOfTokens == 6) {
+        //     uint[6] memory amounts = [uint(0), 0, 0, 0, 0, 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // } else if (_numberOfTokens == 7) {
+        //     uint[7] memory amounts = [uint(0), 0, 0, 0, 0, 0, 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // } else if (_numberOfTokens == 8) {
+        //     // 8 seems to be the max. amount of tokens in a pool
+        //     uint[8] memory amounts = [uint(0), 0, 0, 0, 0, 0, 0, 0];
+        //     amounts[baseAssetIndex] = amount;
+        //     pool.add_liquidity(amounts, 0);
+        // }
+        
+        uint[3] memory amounts = [uint(0), 0, 0];
+        amounts[baseAssetIndex] = amount;
+        pool.add_liquidity(amounts, 0);
+    }
+
+    function _protocolDeposit(uint amount, uint) internal override {
+        gauge.deposit(amount);
+    }
+
+    function _protocolWithdraw(uint amount, uint) internal override {
+        gauge.withdraw(amount);
+    }
+
+    function _totalAssets() internal view override returns (uint) {
+        return gauge.balanceOf(address(this));
+    }
+}

--- a/src/vault/VaultWithStrategy.sol
+++ b/src/vault/VaultWithStrategy.sol
@@ -1,0 +1,97 @@
+pragma solidity ^0.8.15;
+
+import {BaseVault, BaseVaultInitData} from "./BaseVault.sol";
+
+abstract contract VaultWithStrategy is BaseVault {
+    uint256 public lastHarvest;
+    uint256 public autoHarvest; // using a bool will cost more gas since we can't pack it
+    uint256 public harvestCooldown;
+
+    event HarvestCooldownChanged(uint256 oldCooldown, uint256 newCooldown);
+
+    error InvalidHarvestCooldown(uint256 cooldown);
+    error NotStrategy(address sender);
+
+    modifier onlyStrategy() {
+        if (msg.sender != address(this)) revert NotStrategy(msg.sender);
+        _;
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __VaultWithStrategy__init(BaseVaultInitData memory initData, uint _autoHarvest, uint _harvestCooldown)
+        internal 
+        onlyInitializing
+    {
+        __BaseVault__init(initData);
+
+        lastHarvest = block.timestamp;
+        autoHarvest = _autoHarvest;
+        harvestCooldown = _harvestCooldown;
+    }
+
+    function _afterDeposit() internal virtual override {
+        if (autoHarvest == 1 && lastHarvest + harvestCooldown < block.timestamp) {
+            harvest();
+        }
+    }
+
+    function _afterWithdrawal() internal virtual override {
+        if (autoHarvest == 1 && lastHarvest + harvestCooldown < block.timestamp) {
+            harvest();
+        }
+    }
+
+    /**
+     * @notice Set a new harvestCooldown for this adapter. Caller must be owner.
+     * @param newCooldown Time in seconds that must pass before a harvest can be called again.
+     * @dev Cant be longer than 1 day.
+     */
+    function setHarvestCooldown(uint256 newCooldown) external onlyOwner {
+        // Dont wait more than X seconds
+        if (newCooldown >= 1 days) revert InvalidHarvestCooldown(newCooldown);
+
+        emit HarvestCooldownChanged(harvestCooldown, newCooldown);
+
+        harvestCooldown = newCooldown;
+    }
+
+    event AutoHarvestToggled(uint oldValue, uint newValue);
+
+    function toggleAutoHarvest() external onlyOwner {
+        uint256 _autoHarvest = autoHarvest;
+        emit AutoHarvestToggled(_autoHarvest, (_autoHarvest + 1) % 2);
+        // (0 + 1) % 2 = 1
+        // (1 + 1) % 2 = 0
+        autoHarvest = (_autoHarvest + 1) % 2;
+    }
+
+    event Harvest();
+
+    function harvest() public virtual;
+
+    function rewardTokens() public view virtual returns (address[] memory);
+
+    // @dev Exists for compatibility for flywheel systems.
+    function claimRewards() external {
+        harvest();
+    }
+
+    /**
+     * @notice Allows the strategy to deposit assets into the underlying protocol without minting new adapter shares.
+     * @dev This can be used e.g. for a compounding strategy to increase the value of each adapter share.
+     */
+    function strategyDeposit(uint256 amount, uint256 shares) public onlyStrategy {
+        _protocolDeposit(amount, shares);
+    }
+
+    /**
+     * @notice Allows the strategy to withdraw assets from the underlying protocol without burning adapter shares.
+     * @dev This can be used e.g. for a leverage strategy to reduce leverage without the need for the strategy to hold any adapter shares.
+     */
+    function strategyWithdraw(uint256 amount, uint256 shares) public onlyStrategy {
+        _protocolWithdraw(amount, shares);
+    }
+}


### PR DESCRIPTION
Changelog:

- fixed all compiler errors
- removed strategy verification
  - Since each contract is one specific Adapter + Strategy we can be sure that they are compatible. Trade routes could be wrong. But, the verification should be done off-chain to minimize gas costs. The previous implementation only checked the last token in the trade route. Whether the path is really valid, e.g. do these pools really exist, was never checked. I don't think it's worth it to expand it further.
- LP compounder trades reward tokens for the base asset and then deposits that into the Curve pool to get pool LP tokens which it then deposits into the gauge.
- put init data into structs to separate each contract's expected values. The BaseVault init data struct is universal for all vaults. We could pass it to the clone separate from the contract-specific stuff as calldata to save gas on vault creation.


Next steps:
- create tests for abstract BaseVault contract (same thing we do for AdapterBase).
- create tests for CurveLPCompounder
- test out the version with immutable args and compare gas savings.