### PR TITLE
test(strats/aavev3): add delta for deposit & withdrawal

### DIFF
--- a/test/adapter/aave/AaveV3TestConfigStorage.sol
+++ b/test/adapter/aave/AaveV3TestConfigStorage.sol
@@ -11,8 +11,8 @@ contract AaveV3TestConfigStorage is BaseTestConfigStorage {
     constructor() {
         _testConfigs.push(TestConfig({
             asset: WETH,
-            depositDelta: 0,
-            withdrawDelta: 0,
+            depositDelta: 1,
+            withdrawDelta: 1,
             testId: "AaveV3 WETH",
             network: "mainnet",
             blockNumber: 0,


### PR DESCRIPTION
the tests fails because of a rounding issue in the `totalAssets()` calc. 