### PR TITLE
Frax Locked Vault

### DIFF
--- a/src/StakingVaultFactory.sol
+++ b/src/StakingVaultFactory.sol
@@ -6,8 +6,8 @@ contract StakingVaultFactory {
     address[] allVaults;
     event VaultDeployed(address indexed asset, address indexed rewardToken);
 
-    function deploy(address asset, address rewardToken, uint maxLockTime) external {
-        StakingVault vault = new StakingVault(asset, maxLockTime, rewardToken); 
+    function deploy(address asset, address rewardToken, uint maxLockTime, address strategy) external {
+        StakingVault vault = new StakingVault(asset, maxLockTime, rewardToken, strategy); 
         allVaults.push(address(vault));
 
         emit VaultDeployed(asset, rewardToken);

--- a/src/StakingVaultFactory.sol
+++ b/src/StakingVaultFactory.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.0<0.8.20;
+
+import {StakingVault} from "./vaults/StakingVault.sol";
+
+contract StakingVaultFactory {
+    address[] allVaults;
+    event VaultDeployed(address indexed asset, address indexed rewardToken);
+
+    function deploy(address asset, address rewardToken, uint maxLockTime) external {
+        StakingVault vault = new StakingVault(asset, maxLockTime, rewardToken); 
+        allVaults.push(address(vault));
+
+        emit VaultDeployed(asset, rewardToken);
+    }
+}

--- a/src/StakingVaultFactory.sol
+++ b/src/StakingVaultFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.0<0.8.20;
+pragma solidity ^0.8.0 <0.8.20;
 
 import {StakingVault} from "./vaults/StakingVault.sol";
 
@@ -6,8 +6,22 @@ contract StakingVaultFactory {
     address[] allVaults;
     event VaultDeployed(address indexed asset, address indexed rewardToken);
 
-    function deploy(address asset, address rewardToken, uint maxLockTime, address strategy) external {
-        StakingVault vault = new StakingVault(asset, maxLockTime, rewardToken, strategy); 
+    function deploy(
+        address asset,
+        address rewardToken,
+        uint maxLockTime,
+        address strategy,
+        string memory name,
+        string memory symbol
+    ) external {
+        StakingVault vault = new StakingVault(
+            asset,
+            maxLockTime,
+            rewardToken,
+            strategy,
+            name,
+            symbol
+        );
         allVaults.push(address(vault));
 
         emit VaultDeployed(asset, rewardToken);

--- a/src/vaults/StakingVault.sol
+++ b/src/vaults/StakingVault.sol
@@ -107,11 +107,11 @@ contract StakingVault {
         uint currAmount = locks[owner].amount;
         require(currAmount != 0, "NO_LOCK");
 
-        uint newShares = toShares(currAmount + amount, locks[owner].unlockTime - block.timestamp);
+        uint newShares = toShares(amount, locks[owner].unlockTime - block.timestamp);
 
-        totalSupply = totalSupply - locks[owner].shares + newShares;
+        totalSupply = totalSupply + newShares;
         locks[owner].amount = currAmount + amount;
-        locks[owner].shares = newShares;
+        locks[owner].shares += newShares;
 
         asset.safeTransferFrom(msg.sender, address(this), amount);
     

--- a/src/vaults/StakingVault.sol
+++ b/src/vaults/StakingVault.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {ERC20} from "solmate/tokens/ERC20.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+import {IAdapter} from "../interfaces/vault/IAdapter.sol";
 
 struct Lock {
     uint unlockTime;
@@ -17,6 +18,8 @@ contract StakingVault {
     using FixedPointMathLib for uint256;
     ERC20 public immutable asset;
     ERC20 public immutable rewardToken;
+    IAdapter public immutable strategy;
+
     uint public immutable decimals;
     uint public immutable MAX_LOCK_TIME;
     address public constant PROTOCOL_FEE_RECIPIENT = 0x47fd36ABcEeb9954ae9eA1581295Ce9A8308655E;
@@ -37,12 +40,15 @@ contract StakingVault {
     event Claimed(address indexed user, uint amount);
     event DistributeRewards(address indexed distributor, uint amount);
 
-    constructor(address _asset, uint _maxLockTime, address _rewardToken) {
+    constructor(address _asset, uint _maxLockTime, address _rewardToken, address _strategy) {
         asset = ERC20(_asset);
         MAX_LOCK_TIME = _maxLockTime;
         decimals = ERC20(_asset).decimals();
 
         rewardToken = ERC20(_rewardToken);
+
+        strategy = IAdapter(_strategy);
+        ERC20(_asset).approve(_strategy, type(uint).max);
     }
 
     function deposit(address recipient, uint amount, uint lockTime) external returns (uint shares){
@@ -61,22 +67,25 @@ contract StakingVault {
 
         asset.safeTransferFrom(msg.sender, address(this), amount);
 
+        strategy.deposit(amount, address(this));
+
         emit LockCreated(recipient, amount, lockTime);
     }
 
     function withdraw(address owner, address recipient) external {
         _isApproved(owner);
 
-        uint amount = locks[owner].amount;
-        require(amount != 0, "NO_LOCK");
-
-        accrueUser(owner);
+        uint shares = locks[owner].shares;
+        require(shares != 0, "NO_LOCK");
         require(block.timestamp > locks[owner].unlockTime, "LOCKED");
 
-        totalSupply -= locks[owner].shares;
+        accrueUser(owner);
+        uint amount = shares.mulDivDown(strategy.totalAssets(), totalSupply);
+
+        totalSupply -= shares;
         delete locks[owner];
 
-        asset.safeTransfer(recipient, amount);
+        strategy.withdraw(amount, recipient, address(this));
     
         emit Withdrawal(owner, amount);
     }
@@ -88,7 +97,7 @@ contract StakingVault {
 
         uint amount = locks[owner].amount;
         require(amount != 0, "NO_LOCK");
-        require(newLockTime > locks[owner].unlockTime, "INCREASE_LOCK_TIME");
+        require(newLockTime + block.timestamp > locks[owner].unlockTime, "INCREASE_LOCK_TIME");
 
         uint newShares = toShares(locks[owner].amount, newLockTime);
 
@@ -114,13 +123,22 @@ contract StakingVault {
         locks[owner].shares += newShares;
 
         asset.safeTransferFrom(msg.sender, address(this), amount);
+
+        strategy.deposit(amount, address(this));
     
         emit IncreaseLockAmount(owner, amount);
     }
 
     function toShares(uint amount, uint lockTime) public view returns (uint) {
         require(lockTime <= MAX_LOCK_TIME, "LOCK_TIME");
-        return amount.mulDivDown(lockTime, MAX_LOCK_TIME);
+        uint totalAssets = strategy.totalAssets();
+        uint shares;
+        if (totalAssets == 0) {
+            shares = amount;
+        } else {
+            shares = amount.mulDivDown(totalSupply, strategy.totalAssets());
+        }
+        return shares.mulDivDown(lockTime, MAX_LOCK_TIME);
     }
 
     function distributeRewards(uint amount) external {

--- a/src/vaults/StakingVault.sol
+++ b/src/vaults/StakingVault.sol
@@ -1,0 +1,149 @@
+pragma solidity 0.8.19;
+/// @dev 0.8.20 set's the default EVM version to shanghai and uses push0. That's not supported on L2s
+
+import {ERC20} from "solmate/tokens/ERC20.sol";
+import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
+import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
+
+struct Lock {
+    uint unlockTime;
+    uint rewardIndex;
+    uint amount;
+    uint shares;
+}
+
+contract StakingVault {
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    ERC20 public immutable asset;
+    ERC20 public immutable rewardToken;
+    uint public immutable decimals;
+    uint public immutable MAX_LOCK_TIME;
+    
+    mapping(address => Lock) public locks;
+    mapping(address => uint) public accruedRewards;
+    uint public totalSupply;
+    uint public currIndex;
+
+    event LockCreated(address indexed user, uint amount, uint lockTime);
+    event Withdrawal(address indexed user, uint amount);
+    event IncreaseLockTime(address indexed user, uint newLockTime);
+    event IncreaseLockAmount(address indexed user, uint amount);
+    event Claimed(address indexed user, uint amount);
+    event DistributeRewards(address indexed distributor, uint amount);
+
+    constructor(address _asset, uint _maxLockTime, address _rewardToken) {
+        asset = ERC20(_asset);
+        MAX_LOCK_TIME = _maxLockTime;
+        decimals = ERC20(_asset).decimals();
+
+        rewardToken = ERC20(_rewardToken);
+    }
+
+    function deposit(uint amount, uint lockTime) external returns (uint shares){
+        require(locks[msg.sender].unlockTime == 0, "LOCK_EXISTS");
+
+        shares = toShares(amount, lockTime);
+        require(shares != 0, "NO_SHARES");
+
+        totalSupply += shares;
+        locks[msg.sender] = Lock({
+            unlockTime: block.timestamp + lockTime,
+            rewardIndex: currIndex,
+            amount: amount,
+            shares: shares
+        });
+
+        asset.safeTransferFrom(msg.sender, address(this), amount);
+
+        emit LockCreated(msg.sender, amount, lockTime);
+    }
+
+    function withdraw() external {
+        accrueUser(msg.sender);
+        require(block.timestamp > locks[msg.sender].unlockTime, "LOCKED");
+
+        totalSupply -= locks[msg.sender].shares;
+        uint amount = locks[msg.sender].amount;
+        delete locks[msg.sender];
+
+        asset.safeTransfer(msg.sender, amount);
+    
+        emit Withdrawal(msg.sender, amount);
+    }
+
+    function increaseLockTime(uint newLockTime) external {
+        accrueUser(msg.sender);
+
+        uint amount = locks[msg.sender].amount;
+        require(amount != 0, "NO_LOCK");
+        require(newLockTime > locks[msg.sender].unlockTime, "INCREASE_LOCK_TIME");
+
+        uint newShares = toShares(locks[msg.sender].amount, newLockTime);
+
+        totalSupply = totalSupply - locks[msg.sender].shares + newShares;
+        locks[msg.sender].unlockTime = block.timestamp + newLockTime;
+        locks[msg.sender].shares = newShares;
+    
+        emit IncreaseLockTime(msg.sender, newLockTime);
+    }
+
+    function increaseLockAmount(uint amount) external {
+        accrueUser(msg.sender);
+
+        uint currAmount = locks[msg.sender].amount;
+        require(currAmount != 0, "NO_LOCK");
+
+        uint newShares = toShares(currAmount + amount, locks[msg.sender].unlockTime - block.timestamp);
+
+        totalSupply = totalSupply - locks[msg.sender].shares + newShares;
+        locks[msg.sender].amount = currAmount + amount;
+        locks[msg.sender].shares = newShares;
+
+        asset.safeTransferFrom(msg.sender, address(this), amount);
+    
+        emit IncreaseLockAmount(msg.sender, amount);
+    }
+
+    function toShares(uint amount, uint lockTime) public view returns (uint) {
+        require(lockTime <= MAX_LOCK_TIME, "LOCK_TIME");
+        return amount.mulDivDown(lockTime, MAX_LOCK_TIME);
+    }
+
+    function distributeRewards(uint amount) external {
+        // amount of reward tokens that will be distributed per share
+        uint delta = amount.mulDivDown(10 ** decimals, totalSupply);
+        /// @dev if delta == 0, no one will receive any rewards.
+        require(delta != 0, "LOW_AMOUNT") ;
+        currIndex += delta;
+    
+        rewardToken.safeTransferFrom(msg.sender, address(this), amount);
+    
+        emit DistributeRewards(msg.sender, amount);
+    }
+
+    function accrueUser(address user) public {
+        uint shares = locks[user].shares;
+        if (shares == 0) return;
+
+        uint userIndex = locks[user].rewardIndex;
+
+        uint delta = currIndex - userIndex;
+
+        locks[user].rewardIndex = currIndex;
+        accruedRewards[user] += shares * delta / (10 ** decimals);
+    }
+
+    function claim(address user) external {
+        accrueUser(user);
+
+        uint rewards = accruedRewards[user];
+        require(rewards != 0, "NO_REWARDS");
+
+        accruedRewards[user] = 0;
+
+        rewardToken.safeTransfer(user, rewards);
+
+        emit Claimed(msg.sender, rewards);
+    }
+}

--- a/src/vaults/StakingVault.sol
+++ b/src/vaults/StakingVault.sol
@@ -7,8 +7,7 @@ import {SafeTransferLib} from "solmate/utils/SafeTransferLib.sol";
 import {IERC4626} from "../interfaces/vault/IAdapter.sol";
 
 struct Lock {
-    uint128 lockTime;
-    uint128 unlockTime;
+    uint256 unlockTime;
     uint256 rewardIndex;
     uint256 amount;
     uint256 rewardShares;
@@ -101,8 +100,7 @@ contract StakingVault is ERC20 {
         _mint(recipient, shares);
 
         locks[recipient] = Lock({
-            lockTime: uint128(block.timestamp),
-            unlockTime: uint128(block.timestamp + lockTime),
+            unlockTime: block.timestamp + lockTime,
             rewardIndex: currIndex,
             amount: amount,
             rewardShares: rewardShares
@@ -183,32 +181,6 @@ contract StakingVault is ERC20 {
         totalRewardSupply += newRewardShares;
 
         emit IncreaseLockAmount(recipient, amount);
-    }
-
-    function increaseLockTime(uint256 newLockTime) external {
-        accrueUser(msg.sender);
-
-        uint256 amount = locks[msg.sender].amount;
-        require(amount != 0, "NO_LOCK");
-        require(
-            newLockTime + block.timestamp > locks[msg.sender].unlockTime,
-            "INCREASE_LOCK_TIME"
-        );
-
-        uint256 timeLeft = (block.timestamp - locks[msg.sender].lockTime);
-
-        uint256 newRewardShares = toRewardShares(
-            locks[msg.sender].amount,
-            timeLeft + newLockTime
-        );
-
-        totalRewardSupply += (newRewardShares - locks[msg.sender].rewardShares);
-
-        locks[msg.sender].lockTime = uint128(block.timestamp);
-        locks[msg.sender].unlockTime = uint128(block.timestamp + newLockTime);
-        locks[msg.sender].rewardShares = newRewardShares;
-
-        emit IncreaseLockTime(msg.sender, newLockTime);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/vault/StakingVault.t.sol
+++ b/test/vault/StakingVault.t.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 
-import { Clones } from "openzeppelin-contracts/proxy/Clones.sol";
+import {Clones} from "openzeppelin-contracts/proxy/Clones.sol";
 
 import {MockERC20} from "../utils/mocks/MockERC20.sol";
-import { MockERC4626 } from "../utils/mocks/MockERC4626.sol";
-import { IERC20Upgradeable as IERC20 } from "openzeppelin-contracts-upgradeable/interfaces/IERC4626Upgradeable.sol";
+import {MockERC4626} from "../utils/mocks/MockERC4626.sol";
+import {IERC20Upgradeable as IERC20} from "openzeppelin-contracts-upgradeable/interfaces/IERC4626Upgradeable.sol";
 
 import {StakingVault} from "../../src/vaults/StakingVault.sol";
 
@@ -24,27 +24,251 @@ contract StakingVaultTest is Test {
     function setUp() public {
         address adapterImplementation = address(new MockERC4626());
         strategy = MockERC4626(Clones.clone(adapterImplementation));
-        strategy.initialize(IERC20(address(asset)), "Mock Token Vault", "vwTKN");
-        vault = new StakingVault(address(asset), MAX_LOCK_TIME, address(rewardToken), address(strategy));
+        strategy.initialize(
+            IERC20(address(asset)),
+            "Mock Token Vault",
+            "vwTKN"
+        );
+        vault = new StakingVault(
+            address(asset),
+            MAX_LOCK_TIME,
+            address(rewardToken),
+            address(strategy),
+            "VaultName",
+            "v"
+        );
     }
+
+    /*//////////////////////////////////////////////////////////////
+                            DEPOSIT / WITHDRAW
+    //////////////////////////////////////////////////////////////*/
 
     function test_deposit(uint amount) public {
         vm.assume(amount != 0 && amount <= 100_000e18);
         deal(address(asset), alice, amount);
 
+        uint expectedShares = vault.toShares(amount);
+        uint expectedRewardShares = vault.toRewardShares(amount, MAX_LOCK_TIME);
+
         vm.startPrank(alice);
         asset.approve(address(vault), amount);
-        uint shares = vault.deposit(alice, amount, 365 days * 4);
+        uint shares = vault.deposit(alice, amount, MAX_LOCK_TIME);
         vm.stopPrank();
 
-        (uint unlockTime, uint rewardIndex, uint lockAmount, uint lockShares) = vault.locks(alice);
+        (
+            uint unlockTime,
+            uint rewardIndex,
+            uint lockAmount,
+            uint lockRewardShares
+        ) = vault.locks(alice);
 
-        assertEq(unlockTime, block.timestamp + 365 days * 4, "wrong unlock time");
+        assertEq(
+            unlockTime,
+            block.timestamp + MAX_LOCK_TIME,
+            "wrong unlock time"
+        );
         assertEq(rewardIndex, vault.currIndex(), "wrong reward index");
         assertEq(lockAmount, amount, "wrong lock amount");
-        assertEq(shares, lockShares, "wrong shares");
-        assertEq(amount, lockShares, "wrong shares");
+        assertEq(lockRewardShares, expectedRewardShares, "wrong rewardShares");
+        assertEq(shares, expectedShares, "wrong shares");
+        assertEq(asset.balanceOf(alice), 0, "wrong asset bal");
+        assertEq(
+            asset.balanceOf(address(strategy)),
+            amount,
+            "wrong asset bal strat"
+        );
+        assertEq(
+            strategy.balanceOf(address(vault)),
+            amount * 1e9,
+            "wrong strat bal in vault"
+        );
     }
+
+    function test_deposit_for_others() public {
+        uint amount = 1e18;
+        deal(address(asset), alice, amount);
+
+        uint expectedShares = vault.toShares(amount);
+        uint expectedRewardShares = vault.toRewardShares(amount, MAX_LOCK_TIME);
+
+        vm.startPrank(alice);
+        asset.approve(address(vault), amount);
+        uint shares = vault.deposit(bob, amount, MAX_LOCK_TIME);
+        vm.stopPrank();
+
+        (
+            uint unlockTime,
+            uint rewardIndex,
+            uint lockAmount,
+            uint lockRewardShares
+        ) = vault.locks(bob);
+
+        assertEq(
+            unlockTime,
+            block.timestamp + MAX_LOCK_TIME,
+            "wrong unlock time"
+        );
+        assertEq(rewardIndex, vault.currIndex(), "wrong reward index");
+        assertEq(lockAmount, amount, "wrong lock amount");
+        assertEq(lockRewardShares, expectedRewardShares, "wrong rewardShares");
+        assertEq(shares, expectedShares, "wrong shares");
+        assertEq(asset.balanceOf(alice), 0, "wrong asset bal");
+        assertEq(
+            asset.balanceOf(address(strategy)),
+            amount,
+            "wrong asset bal strat"
+        );
+        assertEq(
+            strategy.balanceOf(address(vault)),
+            amount * 1e9,
+            "wrong strat bal in vault"
+        );
+    }
+
+    function test_deposit_with_increased_share_price() public {
+        uint amount = 1e18;
+        _deposit(alice, amount, MAX_LOCK_TIME);
+
+        deal(address(asset), address(alice), amount);
+        vm.prank(alice);
+        asset.transfer(address(strategy), amount);
+
+        _deposit(bob, amount, MAX_LOCK_TIME);
+
+        assertEq(vault.balanceOf(alice), amount, "wrong vault bal alice");
+        assertEq(vault.balanceOf(bob), amount / 2, "wrong vault bal bob");
+        assertEq(
+            asset.balanceOf(address(strategy)),
+            amount * 3,
+            "wrong asset bal strat"
+        );
+    }
+
+    function test_cannot_lock_for_more_than_max() public {
+        deal(address(asset), alice, 1e18);
+        vm.startPrank(alice);
+        asset.approve(address(vault), 1e18);
+        vm.expectRevert("LOCK_TIME");
+        vault.deposit(alice, 1e18, MAX_LOCK_TIME + 1);
+        vm.stopPrank();
+    }
+
+    function test_only_authorized_can_withdraw() public {
+        _deposit(alice, 1e18, 365 days);
+
+        vm.warp(block.timestamp + 365 days + 1);
+
+        vm.startPrank(bob);
+        vm.expectRevert(); // Allowance underflow
+        vault.withdraw(alice, bob);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vault.approve(bob, 1e27);
+
+        vm.prank(bob);
+        vault.withdraw(alice, bob);
+
+        assertEq(asset.balanceOf(bob), 1e18, "Bob didn't receive the funds");
+    }
+
+    function test_withdraw_with_increased_share_price() public {
+        uint amount = 1e18;
+        _deposit(alice, amount, MAX_LOCK_TIME);
+
+        deal(address(asset), address(bob), amount);
+        vm.prank(bob);
+        asset.transfer(address(strategy), amount);
+
+        vm.warp(block.timestamp + MAX_LOCK_TIME + 1);
+
+        vm.prank(alice);
+        vault.withdraw(alice, alice);
+
+        // @dev for some reason solidity decided to have a 1 wei rounding issue here
+        assertApproxEqAbs(
+            vault.balanceOf(alice),
+            0,
+            1,
+            "wrong vault bal alice"
+        );
+        assertApproxEqAbs(
+            asset.balanceOf(alice),
+            amount * 2,
+            1,
+            "wrong asset bal alice"
+        );
+        assertApproxEqAbs(
+            asset.balanceOf(address(strategy)),
+            0,
+            1,
+            "wrong asset bal strat"
+        );
+    }
+
+    function test_cannot_withdraw_twice() public {
+        _deposit(alice, 1e18, 365 days);
+        vm.warp(block.timestamp + 365 days + 1);
+
+        vm.startPrank(alice);
+        vault.withdraw(alice, alice);
+
+        assertEq(
+            asset.balanceOf(alice),
+            1e18,
+            "Alice didn't receive the funds"
+        );
+
+        vm.expectRevert("NO_LOCK");
+        vault.withdraw(alice, alice);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            INCREASE LOCK AMOUNT
+    //////////////////////////////////////////////////////////////*/
+
+    function test_increase_amount(uint amount) public {
+        vm.assume(amount > 1e9 && amount <= 100_000e18);
+
+        uint initalDeposit = 1e18;
+        deal(address(asset), alice, initalDeposit + amount);
+
+        vm.startPrank(alice);
+        asset.approve(address(vault), initalDeposit + amount);
+        vault.deposit(alice, initalDeposit, MAX_LOCK_TIME);
+
+        uint expectedShares = (initalDeposit) + vault.toShares(amount);
+        uint expectedRewardShares = initalDeposit +
+            vault.toRewardShares(amount, MAX_LOCK_TIME / 2);
+
+        vm.warp(block.timestamp + 365 days * 2);
+        vault.increaseLockAmount(alice, amount);
+        vm.stopPrank();
+
+        (, , uint lockAmount, uint lockRewardShares) = vault.locks(alice);
+        assertEq(initalDeposit + amount, lockAmount, "wrong lock amount");
+        assertEq(expectedRewardShares, lockRewardShares, "wrong reward shares");
+        assertEq(expectedShares, vault.balanceOf(alice), "wrong shares");
+    }
+
+    function test_increase_lock_amount_for() public {
+        uint amount = 1e18;
+        _deposit(alice, amount, 365 days);
+
+        deal(address(asset), bob, amount);
+
+        vm.startPrank(bob);
+        asset.approve(address(vault), amount);
+        vault.increaseLockAmount(alice, amount);
+        vm.stopPrank();
+
+        (, , uint deposit, ) = vault.locks(alice);
+        assertEq(deposit, amount * 2, "lock amount didn't change");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            INCREASE LOCK TIME
+    //////////////////////////////////////////////////////////////*/
 
     function test_increase_lock_time(uint newUnlockTime) public {
         // initial lock time is 1 day. `increaseLockTime()` forces you to increase
@@ -56,40 +280,39 @@ contract StakingVaultTest is Test {
         vm.startPrank(alice);
         asset.approve(address(vault), 1e18);
         vault.deposit(alice, 1e18, 1 days);
-        vault.increaseLockTime(alice, newUnlockTime);
+        vault.increaseLockTime(newUnlockTime);
         vm.stopPrank();
 
-        uint expectedShares = 1e18 * newUnlockTime / MAX_LOCK_TIME;
-        (uint unlockTime, ,, uint lockShares) = vault.locks(alice);
-        assertEq(unlockTime, block.timestamp + newUnlockTime, "wrong unlock time");
+        uint expectedShares = (1e18 * newUnlockTime) / MAX_LOCK_TIME;
+        (uint unlockTime, , , uint lockShares) = vault.locks(alice);
+        assertEq(
+            unlockTime,
+            block.timestamp + newUnlockTime,
+            "wrong unlock time"
+        );
         assertEq(lockShares, expectedShares, "wrong shares");
     }
 
-    function test_increase_amount(uint amount) public {
-        vm.assume(amount > 0 && amount <= 100_000e18);
-
-        // 1e18 is the initial deposit amount
-        deal(address(asset), alice, 1e18 + amount);
+    function test_cannot_increase_lock_for_more_than_max() public {
+        vm.expectRevert("LOCK_TIME");
+        _deposit(alice, 1e18, 365 days);
 
         vm.startPrank(alice);
-        asset.approve(address(vault), 1e18 + amount);
-        vault.deposit(alice, 1e18, MAX_LOCK_TIME);
-        vm.warp(block.timestamp + 365 days * 2);
-        vault.increaseLockAmount(alice, amount);
+        vm.expectRevert("LOCK_TIME");
+        vault.increaseLockTime(MAX_LOCK_TIME + 1);
         vm.stopPrank();
-    
-        (,,uint lockAmount, uint lockShares) = vault.locks(alice);
-
-        uint expectedShares = vault.toShares(1e18, MAX_LOCK_TIME) + vault.toShares(amount, MAX_LOCK_TIME / 2);
-        assertEq(1e18 + amount, lockAmount, "wrong lock amount");
-        assertEq(expectedShares, lockShares, "wrong shares");
     }
 
+    /*//////////////////////////////////////////////////////////////
+                            REWARDS
+    //////////////////////////////////////////////////////////////*/
+
     function test_distribute_rewards(uint amount) public {
-        vm.assume(amount > 10e18 && amount < 100_000_000_000e18);
+        //vm.assume(amount > 10e18 && amount < 100_000_000_000e18);
+        amount = 10e18;
         _deposit(alice, 1e18, MAX_LOCK_TIME);
         _deposit(bob, 1e18, MAX_LOCK_TIME / 4);
-    
+
         deal(address(rewardToken), address(this), amount);
         rewardToken.approve(address(vault), amount);
         vault.distributeRewards(amount);
@@ -97,9 +320,19 @@ contract StakingVaultTest is Test {
         vault.accrueUser(alice);
         vault.accrueUser(bob);
 
-        uint amountAfterFees = amount - amount * vault.PROTOCOL_FEE() / 10_000;
-        assertEq(vault.accruedRewards(alice), amountAfterFees * 4 / 5, "Alice got wrong reward amount");
-        assertEq(vault.accruedRewards(bob), amountAfterFees / 5, "Bob got wrong reward amount");
+        uint amountAfterFees = amount -
+            ((amount * vault.PROTOCOL_FEE()) / 10_000);
+
+        assertEq(
+            vault.accruedRewards(alice),
+            (amountAfterFees * 4) / 5,
+            "Alice got wrong reward amount"
+        );
+        assertEq(
+            vault.accruedRewards(bob),
+            amountAfterFees / 5,
+            "Bob got wrong reward amount"
+        );
     }
 
     function test_lock_changes_affect_distribution() public {
@@ -107,39 +340,46 @@ contract StakingVaultTest is Test {
         _deposit(bob, 1e18, MAX_LOCK_TIME / 4);
 
         uint amount = 100e18;
-        uint amountAfterFees = amount - amount * vault.PROTOCOL_FEE() / 10_000;
+        uint amountAfterFees = amount -
+            (amount * vault.PROTOCOL_FEE()) /
+            10_000;
 
         _distribute(amount);
 
         vm.prank(bob);
-        vault.increaseLockTime(bob, MAX_LOCK_TIME / 2);
+        vault.increaseLockTime(MAX_LOCK_TIME / 2);
 
-        assertEq(vault.accruedRewards(bob), amountAfterFees / 5, "Bob got wrong reward amount");
+        assertEq(
+            vault.accruedRewards(bob),
+            amountAfterFees / 5,
+            "Bob got wrong reward amount"
+        );
 
         _distribute(amount);
 
         vault.accrueUser(alice);
         vault.accrueUser(bob);
 
-        uint aliceExpectedRewards = amountAfterFees * 4 / 5 + amountAfterFees * 4 / 6;
-        uint bobExpectedRewards = amountAfterFees / 5 + amountAfterFees * 2 / 6;
+        uint aliceExpectedRewards = (amountAfterFees * 4) /
+            5 +
+            (amountAfterFees * 4) /
+            6;
+        uint bobExpectedRewards = amountAfterFees /
+            5 +
+            (amountAfterFees * 2) /
+            6;
 
-        assertEq(vault.accruedRewards(alice), aliceExpectedRewards, "Alice got wrong reward amount");
-        assertEq(vault.accruedRewards(bob), bobExpectedRewards, "Bob got wrong reward amount");
+        assertEq(
+            vault.accruedRewards(alice),
+            aliceExpectedRewards,
+            "Alice got wrong reward amount"
+        );
+        assertEq(
+            vault.accruedRewards(bob),
+            bobExpectedRewards,
+            "Bob got wrong reward amount"
+        );
     }
-
-    function test_claim() public {
-        _deposit(alice, 1e18, MAX_LOCK_TIME);
-        _distribute(100e18);
-
-        vault.accrueUser(alice);
-        vault.claim(alice);
-
-        uint amountAfterFees = 100e18 - 100e18 * vault.PROTOCOL_FEE() / 10_000;
-
-        assertEq(rewardToken.balanceOf(alice), amountAfterFees, "didn't claim rewards");
-    }
-
 
     function test_accrue_before_amount_increase() public {
         _deposit(alice, 1e18, MAX_LOCK_TIME);
@@ -152,10 +392,16 @@ contract StakingVaultTest is Test {
         vault.increaseLockAmount(alice, 1e18);
         vm.stopPrank();
 
-        uint amountAfterFees = 100e18 - 100e18 * vault.PROTOCOL_FEE() / 10_000;
+        uint amountAfterFees = 100e18 -
+            (100e18 * vault.PROTOCOL_FEE()) /
+            10_000;
         // with the initial balances, alice should receive half of the total reward amount.
         // The increase in her lock amount shouldn't have an affect here.
-        assertEq(vault.accruedRewards(alice), amountAfterFees / 2, "Alice got wrong reward amount");
+        assertEq(
+            vault.accruedRewards(alice),
+            amountAfterFees / 2,
+            "Alice got wrong reward amount"
+        );
     }
 
     function test_accrue_before_lock_time_increase() public {
@@ -164,103 +410,62 @@ contract StakingVaultTest is Test {
         _distribute(100e18);
 
         vm.startPrank(alice);
-        vault.increaseLockTime(alice, 365 days * 2);
+        vault.increaseLockTime(365 days * 2);
         vm.stopPrank();
 
-        uint amountAfterFees = 100e18 - 100e18 * vault.PROTOCOL_FEE() / 10_000;
+        uint amountAfterFees = 100e18 -
+            (100e18 * vault.PROTOCOL_FEE()) /
+            10_000;
         // with the initial lock times, alice should receive half of the total reward amount (100e18)
-        assertEq(vault.accruedRewards(alice), amountAfterFees / 2, "Alice got wrong reward amount");
+        assertEq(
+            vault.accruedRewards(alice),
+            amountAfterFees / 2,
+            "Alice got wrong reward amount"
+        );
     }
 
-    function test_cannot_lock_for_more_than_max() public {
-        deal(address(asset), alice, 1e18);
-        vm.startPrank(alice);
-        asset.approve(address(vault), 1e18);
-        vm.expectRevert("LOCK_TIME");
-        vault.deposit(alice, 1e18, MAX_LOCK_TIME + 1);
-        vm.stopPrank();
+    function test_claim() public {
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
+        _distribute(100e18);
+
+        vault.accrueUser(alice);
+        vault.claim(alice);
+
+        uint amountAfterFees = 100e18 -
+            (100e18 * vault.PROTOCOL_FEE()) /
+            10_000;
+
+        assertEq(
+            rewardToken.balanceOf(alice),
+            amountAfterFees,
+            "didn't claim rewards"
+        );
     }
 
-    function test_cannot_increase_lock_for_more_than_max() public {
-        vm.expectRevert("LOCK_TIME");
-        _deposit(alice, 1e18, 365 days);
-        vm.startPrank(alice);
-        vm.expectRevert("LOCK_TIME");
-        vault.increaseLockTime(alice, MAX_LOCK_TIME + 1);
-        vm.stopPrank();
-    }
+    /*//////////////////////////////////////////////////////////////
+                                TRANSFER
+    //////////////////////////////////////////////////////////////*/
 
-    function test_only_authorized_can_withdraw() public {
-        _deposit(alice, 1e18, 365 days);
-        vm.warp(block.timestamp + 365 days + 1);
-        vm.startPrank(bob);
-        vm.expectRevert("UNAUTHORIZED");
-        vault.withdraw(alice, bob);
-        vm.stopPrank();
+    function testFail_transfer() public {
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
 
         vm.prank(alice);
-        vault.approve(bob, true);
-
-        vm.prank(bob);
-        vault.withdraw(alice, bob);
-
-        assertEq(asset.balanceOf(bob), 1e18, "Bob didn't receive the funds");
+        vault.transfer(bob, 1e18);
     }
 
-    function test_cannot_withdraw_twice() public {
-        _deposit(alice, 1e18, 365 days);
-        vm.warp(block.timestamp + 365 days + 1);
-
-        vm.startPrank(alice);
-        vault.withdraw(alice, alice);
-
-        assertEq(asset.balanceOf(alice), 1e18, "Alice didn't receive the funds");
-
-        vm.expectRevert("NO_LOCK");
-        vault.withdraw(alice, alice);
-    }
-
-    function test_only_authorized_can_increase_lock_time() public {
-        _deposit(alice, 1e18, 365 days);
-
-        vm.startPrank(bob);
-        vm.expectRevert("UNAUTHORIZED");
-        vault.increaseLockTime(alice, 365 days * 2);
-        vm.stopPrank();
+    function testFail_transferFrom() public {
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
 
         vm.prank(alice);
-        vault.approve(bob, true);
+        vault.approve(bob, 1e18);
 
         vm.prank(bob);
-        vault.increaseLockTime(alice, 365 days * 2);
-
-        (uint unlockTime,,,) = vault.locks(alice);
-        assertEq(unlockTime, block.timestamp + 365 days * 2, "lock time didn't change");
+        vault.transferFrom(alice, bob, 1e18);
     }
 
-    function test_only_authorized_can_increase_lock_amount() public {
-        _deposit(alice, 1e18, 365 days);
-
-        deal(address(asset), bob, 1e18);
-        vm.startPrank(bob);
-        asset.approve(address(vault), 1e18);
-        vm.expectRevert("UNAUTHORIZED");
-        vault.increaseLockAmount(alice, 1e18);
-        vm.stopPrank();
-
-        vm.prank(alice);
-        vault.approve(bob, true);
-
-        vm.prank(bob);
-        vault.increaseLockAmount(alice, 1e18);
-
-        (,,uint amount,) = vault.locks(alice);
-        assertEq(amount, 2e18, "lock amount didn't change");
-    }
-
-    //
-    // HELPER FUNCTIONS
-    //
+    /*//////////////////////////////////////////////////////////////
+                            HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
 
     function _deposit(address user, uint amount, uint lockTime) internal {
         deal(address(asset), user, amount);

--- a/test/vault/StakingVault.t.sol
+++ b/test/vault/StakingVault.t.sol
@@ -1,0 +1,194 @@
+pragma solidity ^0.8.0;
+import "forge-std/Test.sol";
+
+import {MockERC20} from "../utils/mocks/MockERC20.sol";
+
+import {StakingVault} from "../../src/vaults/StakingVault.sol";
+
+contract StakingVaultTest is Test {
+    StakingVault vault;
+
+    MockERC20 asset = new MockERC20("A", "Asset", 18);
+    MockERC20 rewardToken = new MockERC20("R", "Reward", 18);
+
+    address alice = vm.addr(1);
+    address bob = vm.addr(2);
+
+    uint MAX_LOCK_TIME = 365 days * 4;
+
+    function setUp() public {
+        vault = new StakingVault(address(asset), MAX_LOCK_TIME, address(rewardToken));
+    }
+
+    function test_deposit(uint amount) public {
+        vm.assume(amount != 0 && amount <= 100_000e18);
+        deal(address(asset), alice, amount);
+
+        vm.startPrank(alice);
+        asset.approve(address(vault), amount);
+        uint shares = vault.deposit(amount, 365 days * 4);
+        vm.stopPrank();
+
+        (uint unlockTime, uint rewardIndex, uint lockAmount, uint lockShares) = vault.locks(alice);
+
+        assertEq(unlockTime, block.timestamp + 365 days * 4, "wrong unlock time");
+        assertEq(rewardIndex, vault.currIndex(), "wrong reward index");
+        assertEq(lockAmount, amount, "wrong lock amount");
+        assertEq(shares, lockShares, "wrong shares");
+        assertEq(amount, lockShares, "wrong shares");
+    }
+
+    function test_increase_lock_time(uint newUnlockTime) public {
+        // initial lock time is 1 day. `increaseLockTime()` forces you to increase
+        // the lock time so limit the min value as well
+        vm.assume(newUnlockTime > 2 days && newUnlockTime <= MAX_LOCK_TIME);
+
+        deal(address(asset), alice, 1e18);
+
+        vm.startPrank(alice);
+        asset.approve(address(vault), 1e18);
+        vault.deposit(1e18, 1 days);
+        vault.increaseLockTime(newUnlockTime);
+        vm.stopPrank();
+
+        uint expectedShares = 1e18 * newUnlockTime / MAX_LOCK_TIME;
+        (uint unlockTime, ,, uint lockShares) = vault.locks(alice);
+        assertEq(unlockTime, block.timestamp + newUnlockTime, "wrong unlock time");
+        assertEq(lockShares, expectedShares, "wrong shares");
+    }
+
+    function test_increase_amount(uint amount) public {
+        vm.assume(amount > 0 && amount <= 100_000e18);
+
+        // 1e18 is the initial deposit amount
+        deal(address(asset), alice, 1e18 + amount);
+
+        vm.startPrank(alice);
+        asset.approve(address(vault), 1e18 + amount);
+        vault.deposit(1e18, MAX_LOCK_TIME);
+        vault.increaseLockAmount(amount);
+        vm.stopPrank();
+    
+        (,,uint lockAmount, uint lockShares) = vault.locks(alice);
+
+        uint expectedShares = vault.toShares(1e18 + amount, MAX_LOCK_TIME);
+        assertEq(1e18 + amount, lockAmount, "wrong lock amount");
+        assertEq(expectedShares, lockShares, "wrong shares");
+    }
+
+    function test_distribute_rewards(uint amount) public {
+        vm.assume(amount > 10e18 && amount < 100_000_000_000e18);
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
+        _deposit(bob, 1e18, MAX_LOCK_TIME / 4);
+    
+        deal(address(rewardToken), address(this), amount);
+        rewardToken.approve(address(vault), amount);
+        vault.distributeRewards(amount);
+
+        vault.accrueUser(alice);
+        vault.accrueUser(bob);
+
+        assertEq(vault.accruedRewards(alice), amount * 4 / 5, "Alice got wrong reward amount");
+        assertEq(vault.accruedRewards(bob), amount / 5, "Bob got wrong reward amount");
+    }
+
+    function test_lock_changes_affect_distribution() public {
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
+        _deposit(bob, 1e18, MAX_LOCK_TIME / 4);
+
+        uint amount = 100e18;
+
+        _distribute(amount);
+
+        vm.prank(bob);
+        vault.increaseLockTime(MAX_LOCK_TIME / 2);
+
+        assertEq(vault.accruedRewards(bob), amount / 5, "Bob got wrong reward amount");
+
+        _distribute(amount);
+
+        vault.accrueUser(alice);
+        vault.accrueUser(bob);
+
+        uint aliceExpectedRewards = amount * 4 / 5 + amount * 4 / 6;
+        uint bobExpectedRewards = amount / 5 + amount * 2 / 6;
+
+        assertEq(vault.accruedRewards(alice), aliceExpectedRewards, "Alice got wrong reward amount");
+        assertEq(vault.accruedRewards(bob), bobExpectedRewards, "Bob got wrong reward amount");
+    }
+
+    function test_claim() public {
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
+        _distribute(100e18);
+
+        vault.accrueUser(alice);
+        vault.claim(alice);
+
+        assertEq(rewardToken.balanceOf(alice), 100e18, "didn't claim rewards");
+    }
+
+    function test_accrue_before_amount_increase() public {
+        _deposit(alice, 1e18, MAX_LOCK_TIME);
+        _deposit(bob, 1e18, MAX_LOCK_TIME);
+        _distribute(100e18);
+
+        deal(address(asset), alice, 1e18);
+        vm.startPrank(alice);
+        asset.approve(address(vault), 1e18);
+        vault.increaseLockAmount(1e18);
+        vm.stopPrank();
+
+        // with the initial balances, alice should receive half of the total reward amount (100e18)
+        // The increase in her lock amount shouldn't have an affect here.
+        assertEq(vault.accruedRewards(alice), 50e18, "Alice got wrong reward amount");
+    }
+
+    function test_accrue_before_lock_time_increase() public {
+        _deposit(alice, 1e18, 365 days);
+        _deposit(bob, 1e18, 365 days);
+        _distribute(100e18);
+
+        vm.startPrank(alice);
+        vault.increaseLockTime(365 days * 2);
+        vm.stopPrank();
+
+        // with the initial lock times, alice should receive half of the total reward amount (100e18)
+        assertEq(vault.accruedRewards(alice), 50e18, "Alice got wrong reward amount");
+    }
+
+    function test_cannot_lock_for_more_than_max() public {
+        deal(address(asset), alice, 1e18);
+        vm.startPrank(alice);
+        asset.approve(address(vault), 1e18);
+        vm.expectRevert("LOCK_TIME");
+        vault.deposit(1e18, MAX_LOCK_TIME + 1);
+        vm.stopPrank();
+    }
+
+    function test_cannot_increase_lock_for_more_than_max() public {
+        vm.expectRevert("LOCK_TIME");
+        _deposit(alice, 1e18, 365 days);
+        vm.startPrank(alice);
+        vm.expectRevert("LOCK_TIME");
+        vault.increaseLockTime(MAX_LOCK_TIME + 1);
+        vm.stopPrank();
+    }
+
+    //
+    // HELPER FUNCTIONS
+    //
+
+    function _deposit(address user, uint amount, uint lockTime) internal {
+        deal(address(asset), user, amount);
+        vm.startPrank(user);
+        asset.approve(address(vault), amount);
+        vault.deposit(amount, lockTime);
+        vm.stopPrank();
+    }
+
+    function _distribute(uint amount) internal {
+        deal(address(rewardToken), address(this), amount);
+        rewardToken.approve(address(vault), amount);
+        vault.distributeRewards(amount);
+    }
+}

--- a/test/vault/StakingVault.t.sol
+++ b/test/vault/StakingVault.t.sol
@@ -66,12 +66,13 @@ contract StakingVaultTest is Test {
         vm.startPrank(alice);
         asset.approve(address(vault), 1e18 + amount);
         vault.deposit(alice, 1e18, MAX_LOCK_TIME);
+        vm.warp(block.timestamp + 365 days * 2);
         vault.increaseLockAmount(alice, amount);
         vm.stopPrank();
     
         (,,uint lockAmount, uint lockShares) = vault.locks(alice);
 
-        uint expectedShares = vault.toShares(1e18 + amount, MAX_LOCK_TIME);
+        uint expectedShares = vault.toShares(1e18, MAX_LOCK_TIME) + vault.toShares(amount, MAX_LOCK_TIME / 2);
         assertEq(1e18 + amount, lockAmount, "wrong lock amount");
         assertEq(expectedShares, lockShares, "wrong shares");
     }


### PR DESCRIPTION
Features:
- Vault deposits can be locked up to `MaxLockTime` to earn incentives.
- Vault deposits will be deposited into underlying 4626 strategies to earn additional assets.
- Strategy accounting and reward accounting is separate. 
  (Strategy accounting is based purely on asset amounts. Reward accounting is based on asset amounts and lock time)
- Vault creator can set `MaxLockTime`
- Vault is immutable.
- Users can claim rewards at any time but only withdraw their assets after their lock time has ended.
- Rewards have to be added dynamically and will be paid out instantly.
  (This allows the rewarder to adjust rates week by week)
- Vault shares cant be transfered. Only minted or burned.
- VaultFactory deploys new vaults.
- VaultCraft earns a part of paid out rewards.